### PR TITLE
update to egui 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-datepicker"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Adds date picker widget for egui gui library"
@@ -15,7 +15,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eframe = "0.14"
+eframe = "0.15"
 chrono = "0.4"
 num-traits = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library provide a simple date picker widget for egui with some customizatio
 Add `egui-datepicker` as dependency to your project
 ```toml
 [dependencies]
-egui-datepicker = "0.1"
+egui-datepicker = "0.2"
 ```
 
 Import necessary structs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,20 +173,18 @@ where
     }
 
     fn show_day_button(&mut self, date: Date<Tz>, ui: &mut Ui) {
-        ui.centered_and_justified(|ui| {
-            let mut day_button = egui::Button::new(date.day().to_string());
-            if self.date == &date {
-                day_button = day_button.enabled(false);
-            }
-            if self.date.month() != date.month() {
-                ui.style_mut().visuals.button_frame = false;
-            }
-            if self.highlight_weekend && self.weekend_days.contains(&date.weekday()) {
-                ui.style_mut().visuals.override_text_color = Some(self.weekend_color);
-            }
-            if ui.add(day_button).clicked() {
-                *self.date = date;
-            }
+        ui.add_enabled_ui(self.date != &date, |ui| {
+            ui.centered_and_justified(|ui| {
+                if self.date.month() != date.month() {
+                    ui.style_mut().visuals.button_frame = false;
+                }
+                if self.highlight_weekend && self.weekend_days.contains(&date.weekday()) {
+                    ui.style_mut().visuals.override_text_color = Some(self.weekend_color);
+                }
+                if ui.button(date.day().to_string()).clicked() {
+                    *self.date = date;
+                }
+            });
         });
     }
 


### PR DESCRIPTION
Only change is that `Button` now has no `enabled()` method; adding a disabled view is done via `ui.add_enabled_ui()` instead.

Thanks for this super useful widget!