### PR TITLE
bumped eframe to version 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eframe = "0.16"
+eframe = "0.17"
 chrono = "0.4"
 num-traits = "0.2"
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -22,7 +22,7 @@ impl epi::App for ExampleApp {
         "Datepicker example"
     }
 
-    fn update(&mut self, ctx: &egui::CtxRef, _frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &epi::Frame) {
         // ctx.set_debug_on_hover(true);
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::Grid::new("exaamples_grid").show(ui, |ui| {


### PR DESCRIPTION
A super trivial version bump of eframe from 0.16 to 0.17 .

Also, this widget is great, thank you!