### PR TITLE
Added ability to translate strings, embed a french translation

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -55,6 +55,13 @@ impl epi::App for ExampleApp {
                         .weekend_days(|date| date.day() % 2 == 0),
                 );
                 ui.end_row();
+
+                ui.label("Translation (French)");
+                ui.add(
+                    DatePicker::new("translationfrench", &mut self.date)
+                        .translation(&translation::TRANSLATION_FRENCH),
+                );
+                ui.end_row();
             });
         });
     }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -1,0 +1,47 @@
+/// A translation for strings used by egui-datepicker
+pub struct DateTranslation {
+    /// The full-lenght twelve month of a year (starting at January)
+    pub month: [&'static str; 12],
+    /// A shortened version of the 7 days of the week (starting at Sunday)
+    pub weekday_short: [&'static str; 7],
+    /// Translation of the "today" button, that set the date to the current date when clicked
+    pub today: &'static str,
+}
+
+pub const TRANSLATION_ENGLISH: DateTranslation = DateTranslation {
+    month: [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ],
+    weekday_short: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+    today: "Today",
+};
+
+pub const TRANSLATION_FRENCH: DateTranslation = DateTranslation {
+    month: [
+        "janvier",
+        "février",
+        "mars",
+        "avril",
+        "mai",
+        "juin",
+        "juillet",
+        "août",
+        "septembre",
+        "octobre",
+        "novembre",
+        "décembre",
+    ],
+    weekday_short: ["dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam."],
+    today: "Aujourd'hui",
+};


### PR DESCRIPTION
I needed a date picker for a school project (where I choosed to use egui). As it's in french, I added the ability to translate. This is a pretty basic translation method, but it should work as long as you don't need to load new translation after initialisation (with lazy_init or something. Or just const).